### PR TITLE
Expose removed band during slot operations

### DIFF
--- a/src/application/scheduleService.js
+++ b/src/application/scheduleService.js
@@ -23,16 +23,16 @@ function addRow(project, dayLabel, atIndex) {
  * 行削除
  */
 function removeRow(project, dayLabel, atIndex) {
-  const { project: p } = Ops.removeRow(project, dayLabel, atIndex);
-  return { project: p, conflicts: Ops.detectConflicts(p) };
+  const { project: p, removedBandId } = Ops.removeRow(project, dayLabel, atIndex);
+  return { project: p, removedBandId, conflicts: Ops.detectConflicts(p) };
 }
 
 /**
  * ドラッグ&ドロップ配置（入れ替えは UI 側で index を指定して呼ぶ）
  */
 function place(project, dayLabel, index, bandId) {
-  const p = Ops.placeBand(project, dayLabel, index, bandId);
-  return { project: p, conflicts: Ops.detectConflicts(p) };
+  const { project: p, removedBandId } = Ops.placeBand(project, dayLabel, index, bandId);
+  return { project: p, removedBandId, conflicts: Ops.detectConflicts(p) };
 }
 
 /**

--- a/src/domain/scheduleOps.js
+++ b/src/domain/scheduleOps.js
@@ -76,21 +76,22 @@ function removeRow(project, dayLabel, atIndex) {
  * @param {string} dayLabel
  * @param {number} index
  * @param {string} bandId
- * @returns {import('./entities').Project}
+ * @returns {{project: import('./entities').Project, removedBandId?: string}}
  */
 function placeBand(project, dayLabel, index, bandId) {
   const p = ensureSchedule(project);
   const band = p.bands.find(b => b.id === bandId);
   const day = p.days.find(d => d.label === dayLabel);
   const sched = p.timetable.days.find(d => d.label === dayLabel);
-  if (!band || !day || !sched) return p;
-  if (index < 0 || index >= sched.slots.length) return p;
+  if (!band || !day || !sched) return { project: p };
+  if (index < 0 || index >= sched.slots.length) return { project: p };
 
   const target = sched.slots[index];
+  const removed = target.bandId;
   // 入れ替え: 既存バンドがいたら palette に戻った扱い
   target.bandId = band.id;
   target.durationMin = band.durationMin || day.defaultDurationMin;
-  return p;
+  return { project: p, removedBandId: removed };
 }
 
 /**


### PR DESCRIPTION
## Summary
- expose removed band id when deleting rows or overwriting slots
- propagate removed band id through application service for UI handling

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b6e08f41608323bd740f92b2d54e21